### PR TITLE
feat: add output-format option (md or json) and exporter of questions…

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,3 +3,4 @@ default_vscdb_dir_paths:
   Darwin: "~/Library/Application Support/Cursor/User/workspaceStorage"
   Linux: "~/.config/Cursor/User/workspaceStorage"
 aichat_query: "SELECT value FROM ItemTable WHERE [key] IN ('workbench.panel.aichat.view.aichat.chatdata');"
+context_query: "SELECT value FROM ItemTable WHERE [key] IN ('aiService.prompts', 'src.vs.platform.reactivestorage.browser.reactiveStorageServiceImpl.persistentStorage.workspaceUser');"

--- a/src/vscdb.py
+++ b/src/vscdb.py
@@ -43,7 +43,24 @@ class VSCDBQuery:
         except Exception as e:
             logger.error(f"Unexpected error: {e}")
             return {"error": str(e)}
-        
+
+    def query_context_data(self) -> list[Any] | dict[str, str]:
+        try:
+            with open('config.yml', 'r') as config_file:
+                config = yaml.safe_load(config_file)
+            query = config['context_query']
+            logger.debug("Loaded Context query from config.yaml")
+            return self.query_to_json(query)
+        except FileNotFoundError as e:
+            logger.error(f"Config file not found: {e}")
+            return {"error": str(e)}
+        except yaml.YAMLError as e:
+            logger.error(f"Error parsing config file: {e}")
+            return {"error": str(e)}
+        except Exception as e:
+            logger.error(f"Unexpected error: {e}")
+            return {"error": str(e)}
+
     def query_aichat_data(self) -> list[Any] | dict[str, str]:
         """
         Query the AI chat data from the database.


### PR DESCRIPTION
… with codebase context

Example usage with the new json format:
```
export --output-dir "~/cursor-chat-export/data" --output-format json
```

Example output of md with context:
```md
# Chat Transcript - Tab 1

## User:


[text]  
@Codebase Summarize this project


[context]
- README.md: 0.47
- packages/core/src/indexing/chunk/ChunkCodebaseIndex.ts: 0.46
- packages/core/src/context/providers/CodebaseContextProvider.ts: 0.45
- packages/core/src/indexing/CodeSnippetsIndex.ts: 0.45
- packages/core/src/indexing/CodebaseIndexer.ts: 0.44
- packages/core/src/indexing/FullTextSearchCodebaseIndex.ts: 0.42
- packages/core/src/indexing/TestCodebaseIndex.ts: 0.42
- packages/core/src/indexing/README.md: 0.4
```

Example output of json with context:
```json
[
  {
    "user": {
      "text": "@Codebase Summarize this project",
      "context": [
        {
          "file": {
            "relativeWorkspacePath": "README.md"
          },
          "score": 0.46909475326538086
        },
        {
          "file": {
            "relativeWorkspacePath": "packages/core/src/indexing/chunk/ChunkCodebaseIndex.ts"
          },
          "score": 0.45642781257629395
        }
	  ]
	}
   },
  {
    "ai": {
      "model": "gpt-4o-mini",
      "text": ""
    }
  },
]
```