### PR TITLE
MacOS Python3 error export.py unexpected character after line continuation character

### DIFF
--- a/src/export.py
+++ b/src/export.py
@@ -89,7 +89,8 @@ class MarkdownChatFormatter(ChatFormatter):
                         
                         # Selections
                         if "selections" in bubble and bubble["selections"]:
-                            user_text.append(f"[selections]  \n" + "\n".join([s['text'] for s in bubble['selections']]))
+                            selections_text = "\n".join(s['text'] for s in bubble['selections'])
+                            user_text.append(f"[selections]  \n{selections_text}")
                         
                         # Images
                         if 'image' in bubble and image_dir is not None:

--- a/src/export.py
+++ b/src/export.py
@@ -89,7 +89,7 @@ class MarkdownChatFormatter(ChatFormatter):
                         
                         # Selections
                         if "selections" in bubble and bubble["selections"]:
-                            user_text.append(f"[selections]  \n{"\n".join([s["text"] for s in bubble['selections']])}")
+                            user_text.append(f"[selections]  \n" + "\n".join([s['text'] for s in bubble['selections']]))
                         
                         # Images
                         if 'image' in bubble and image_dir is not None:


### PR DESCRIPTION
On MacOS with `Python 3.11.6`

`chat.py discover`

results in the error :
```
Traceback (most recent call last):
  File "/Users/andy/projects/cursor-chat-export/chat.py", line 7, in <module>
    from src.export import ChatExporter, MarkdownChatFormatter, MarkdownFileSaver
  File "/Users/andy/projects/cursor-chat-export/src/export.py", line 92
    user_text.append(f"[selections]  \n{"\n".join([s["text"] for s in bubble['selections']])}")
                                          ^
SyntaxError: unexpected character after line continuation character
```

This PR fixes the issue in the f-string with the use of backslash